### PR TITLE
サブドメインでアクセスしたIDをもとにENV API KEYを参照する

### DIFF
--- a/colu_api/index.js
+++ b/colu_api/index.js
@@ -10,7 +10,7 @@ var Colu = require('colu');
 
 require('dotenv').config();
 
-var community_id = "";
+var communityId = "";
 var coluSettings = {
   network: process.env.COLU_SDK_NETWORK,
   apiKey: process.env.COLU_SDK_API_KEY,
@@ -22,12 +22,12 @@ app.use(function(req, res, next) {
     subDomain = domain.split('.');
 
   if (subDomain[0]) {
-    community_id = subDomain[0];
+    communityId = subDomain[0].toUpperCase();
 
     coluSettings = {
-      network: process.env[community_id + "_COLU_SDK_NETWORK"],
-      apiKey: process.env[community_id + "_COLU_SDK_API_KEY"],
-      privateSeed: process.env[community_id + "_COLU_SDK_PRIVATE_SEED"],
+      network: process.env[communityId + "_COLU_SDK_NETWORK"],
+      apiKey: process.env[communityId + "_COLU_SDK_API_KEY"],
+      privateSeed: process.env[communityId + "_COLU_SDK_PRIVATE_SEED"],
     };
   }
 

--- a/colu_api/package.json
+++ b/colu_api/package.json
@@ -17,6 +17,7 @@
     "colu": "^0.11.0",
     "dotenv": "^2.0.0",
     "express": "^4.14.0",
+    "express-subdomain": "1.0.5",
     "request": "^2.75.0",
     "socket.io": "^1.5.1"
   }


### PR DESCRIPTION
## 目的

https://abc.zenos.herokuapp.com
https://gifted.zenos.herokuapp.com

などのドメインでアクセスした時に、
それぞれのコミュニティ通貨のIDに応じた、
coluの処理を返すようにする。

## 背景

今後、複数の通貨が運用されるため。

## 注意点

データベースなどで実装するのが、
手間だったので、envファイルの参照IDを変えているだけの実装。

将来的にDBを使いたい